### PR TITLE
Fix build to copy assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/copy-assets.js",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/copy-assets.js
+++ b/scripts/copy-assets.js
@@ -1,0 +1,17 @@
+const { cpSync, mkdirSync } = require('fs');
+const { join } = require('path');
+
+const root = process.cwd();
+const dist = join(root, 'dist');
+
+mkdirSync(dist, { recursive: true });
+
+// Copy config.json
+cpSync(join(root, 'config.json'), join(dist, 'config.json'));
+
+// Copy assets directory recursively
+cpSync(join(root, 'assets'), join(dist, 'assets'), { recursive: true });
+
+console.log('Assets and config.json copied to dist');
+
+


### PR DESCRIPTION
## Summary
- keep npm lockfile ignored
- copy images and config into dist after building

## Testing
- `bun run build`
