### PR TITLE
Fix volume fade out-of-range error

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -11,6 +11,32 @@ export const AudioPlayer: React.FC = () => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [timeLeft, setTimeLeft] = useState(INITIAL_TIME);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const fadeAnimRef = useRef<number | null>(null);
+
+  const fadeVolume = (from: number, to: number, duration = 200) => {
+    const audio = audioRef.current;
+    if (!audio) return Promise.resolve();
+    if (fadeAnimRef.current !== null) {
+      cancelAnimationFrame(fadeAnimRef.current);
+      fadeAnimRef.current = null;
+    }
+    return new Promise<void>((resolve) => {
+      const start = performance.now();
+      const step = (now: number) => {
+        const progress = Math.min((now - start) / duration, 1);
+        const nextVol = from + (to - from) * progress;
+        // Clamp the volume to avoid out-of-range errors due to timing glitches
+        audio.volume = Math.min(1, Math.max(0, nextVol));
+        if (progress < 1) {
+          fadeAnimRef.current = requestAnimationFrame(step);
+        } else {
+          fadeAnimRef.current = null;
+          resolve();
+        }
+      };
+      fadeAnimRef.current = requestAnimationFrame(step);
+    });
+  };
 
   const formatTime = (sec: number) => {
     const m = Math.floor(sec / 60)
@@ -23,13 +49,17 @@ export const AudioPlayer: React.FC = () => {
   const startTimer = () => {
     const audio = audioRef.current;
     if (!audio) return;
+    audio.volume = 0;
     audio.play().catch(() => {});
+    fadeVolume(0, 1).catch(() => {});
     timerRef.current = setInterval(() => {
       setTimeLeft((t) => {
         if (t <= 1) {
           clearInterval(timerRef.current!);
           timerRef.current = null;
-          audio.pause();
+          fadeVolume(audio.volume, 0)
+            .then(() => audio.pause())
+            .catch(() => {});
           setIsPlaying(false);
           setTimeout(() => setTimeLeft(INITIAL_TIME), 300);
           return 0;
@@ -42,7 +72,9 @@ export const AudioPlayer: React.FC = () => {
   const stopTimer = () => {
     const audio = audioRef.current;
     if (!audio) return;
-    audio.pause();
+    fadeVolume(audio.volume, 0)
+      .then(() => audio.pause())
+      .catch(() => {});
     if (timerRef.current) {
       clearInterval(timerRef.current);
       timerRef.current = null;


### PR DESCRIPTION
## Summary
- clamp computed audio volume to [0,1] during fade animation

## Testing
- `npm run build`
